### PR TITLE
Restore XML file format and AGA info

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -23,7 +23,7 @@ class ReportsController < ApplicationController
   end
 
   def invoices
-    users = User.yr(@year).to_a
+    users = User.yr(@year).confirmed.to_a
     @user_count = users.count
     @invoice_total_across_all_users = users.map(&:get_invoice_total).reduce(:+)
   end
@@ -52,7 +52,7 @@ class ReportsController < ApplicationController
     min = params[:min].downcase
     max = params[:max].downcase
     [min, max].each { |m| raise "Invalid param" unless ("a".."z").cover?(m) }
-    @users = User.yr(@year).email_range(min, max).order(:email).to_a
+    @users = User.yr(@year).confirmed.email_range(min, max).order(:email).to_a
     render :layout => "print"
   end
 

--- a/app/controllers/rpt/attendee_reports_controller.rb
+++ b/app/controllers/rpt/attendee_reports_controller.rb
@@ -4,7 +4,7 @@ class Rpt::AttendeeReportsController < Rpt::AbstractReportController
     respond_to do |format|
       format.html do
         @attendee_count = @attendees.count
-        @user_count = User.yr(@year).count
+        @user_count = User.yr(@year).confirmed.count
         @cancelled_attendee_count = Attendee.yr(@year).attendee_cancelled.count
         @planless_attendee_count = Attendee.yr(@year).planless.count
         @planful_attendee_count = Attendee.yr(@year).count - @planless_attendee_count

--- a/app/controllers/rpt/attendeeless_user_reports_controller.rb
+++ b/app/controllers/rpt/attendeeless_user_reports_controller.rb
@@ -1,6 +1,6 @@
 class Rpt::AttendeelessUserReportsController < Rpt::AbstractReportController
   def show
-    users = User.yr(@year).attendeeless.select(:email)
+    users = User.yr(@year).confirmed.attendeeless.select(:email)
     @email_list = users.map(&:email).join(', ')
   end
 end

--- a/app/controllers/rpt/cost_summary_reports_controller.rb
+++ b/app/controllers/rpt/cost_summary_reports_controller.rb
@@ -2,7 +2,7 @@ class Rpt::CostSummaryReportsController < Rpt::AbstractReportController
   def show
     respond_to do |format|
       format.html do
-        @user_count = User.yr(@year).count
+        @user_count = User.yr(@year).confirmed.count
         @attendee_count = Attendee.yr(@year).count
       end
       format.csv do

--- a/app/controllers/rpt/outstanding_balance_reports_controller.rb
+++ b/app/controllers/rpt/outstanding_balance_reports_controller.rb
@@ -2,7 +2,7 @@ class Rpt::OutstandingBalanceReportsController < Rpt::AbstractReportController
   def show
     # When generating invoices for multiple users, the `includes`
     # can really speed things up.
-    @users = User.yr(@year).includes([
+    @users = User.yr(@year).confirmed.includes([
       {
         :attendees => [
           { :attendee_activities => :activity },

--- a/app/controllers/rpt/tournament_reports_controller.rb
+++ b/app/controllers/rpt/tournament_reports_controller.rb
@@ -6,5 +6,22 @@ class Rpt::TournamentReportsController < Rpt::AbstractReportController
     @page_title = @tournament.name
 
     @players = @tournament.attendees
+
+    @aga_member_info = AgaTdList.data
+
+    respond_to do |format|
+      format.html do
+        @players_count = @players.count
+        render :show
+      end
+      format.xml do
+        xml = PlayersXmlExporter.render(@players, @aga_member_info)
+        send_data xml, filename: xml_filename, type: 'text/xml'
+      end
+    end
+  end
+
+  def xml_filename
+    "#{helpers.slugify(@tournament.name, '_')}_players_#{Time.current.strftime('%Y-%m-%d')}.xml"
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,7 +57,7 @@ class UsersController < ApplicationController
     else
       sort_order = "role = 'A' desc, role = 'S' desc"
     end
-    @users = @users.yr(@year).order(Arel.sql(sort_order)).includes(:attendees)
+    @users = @users.yr(@year).confirmed.order(Arel.sql(sort_order)).includes(:attendees)
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -114,4 +114,8 @@ module ApplicationHelper
     v = cents_for_currency_field(cents)
     builder.number_field atr, min: 0, size: 5, step: 0.01, value: v
   end
+
+  def slugify str, separator = '-'
+    str.downcase.strip.gsub(' ', separator).gsub(/[^\w-]/, '')
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,8 +60,14 @@ class User < ApplicationRecord
     where("(select count(*) from attendees a where a.user_id = users.id) = 0")
   }
 
+  # Class Methods
+  # -------------
   def self.email_range min, max
     where('lower(substr(email, 1, 1)) between ? and ?', min, max)
+  end
+
+  def self.confirmed
+    where.not(:confirmed_at => nil)
   end
 
   # Instance Methods

--- a/app/views/registrations/aga_member_search.html.haml
+++ b/app/views/registrations/aga_member_search.html.haml
@@ -45,7 +45,14 @@
 
     if (results.length) {
       displayResults(results)
+    } else {
+      displayNoResults();
     }
+  }
+
+  const displayNoResults = results => {
+    displaySearchingMessage(false);
+    searchResultsContainer.innerHTML = 'No results found.';
   }
 
   const displayResults = results => {
@@ -77,6 +84,7 @@
   // Toggle a "searching" message to make clear that something is happening once
   // a user types
   const displaySearchingMessage = (state = true) => {
+    searchResultsContainer.innerHTML = '';
     searchingMessage.classList.toggle('initially-hidden', !state);
   }
 

--- a/app/views/rpt/tournament_reports/show.html.haml
+++ b/app/views/rpt/tournament_reports/show.html.haml
@@ -8,19 +8,33 @@
 
 %p
   There are
-  = pluralize(@players.count, amnh.downcase)
+  = usgc_pluralize(@players.count, amnh.downcase)
   registered to play in the U.S. Open.
 
-%table.player-list
+%table.player-list.semantic
   %thead
     %tr
       %th Player Name
+      %th Rank
+      %th AGA Rating
+      %th Last Rated
+      %th Flag
   %tbody
   - @players.each do |player|
+    - aga_info = @aga_member_info[player.aga_id]
     %tr
       %td
         = NameInflector.capitalize(player.given_name)
         = NameInflector.capitalize(player.family_name)
+        - if player.aga_id
+          (#{link_to "#{player.aga_id}", "http://agagd.usgo.org/player/#{player.aga_id}"})
+        %td= player.rank_name
+        %td= aga_info ? aga_info[:rating] : '-'
+        %td= aga_info ? aga_info[:last_rated_on] : '-'
+        %td
+          - if aga_info
+            - if self_promoter(player, aga_info[:rating])
+              Self-promoted
 
 %h3 Export to XML
 %p Import into OpenGotha by selecting <strong>Tournament &rarr; Import &hellip; &rarr; Import Tournament From XML File</strong>.

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -11,7 +11,13 @@ RSpec.describe UsersController, :type => :controller do
   render_views
 
   let(:user) { create :user }
-  let(:user_attributes) { { :email => "test@example.com", :password => "password", :password_confirmation => "password" } }
+  let(:user_attributes) {
+    {
+      :email => "test@example.com",
+      :password => "password",
+      :password_confirmation => "password"
+    }
+  }
   let(:wrong_year) { user.year - 1 }
   let(:year) { Time.zone.now.year }
 


### PR DESCRIPTION
This restores the logic necessary to generate the XML files for player list imports to OpenGotha. I also restored the information from the AGA TD List. We'll want to refactor that part of the site to use info from the Membership API instead of manually scraping the TD list, but it can stay as-is for now.

Also pre-emptively merges in recent commits from main because sometimes I am the most careful at git. 😬 